### PR TITLE
Disabled Social Account Email Verification and Customized Email based Authentication

### DIFF
--- a/backend/authentication/adapters.py
+++ b/backend/authentication/adapters.py
@@ -1,5 +1,10 @@
-from allauth.account.adapter import DefaultAccountAdapter
+from allauth.account.adapter import (
+    DefaultAccountAdapter,
+    get_adapter as get_account_adapter,
+)
+from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
 from django.conf import settings
+from .utils import set_primary_email
 
 
 class CustomAccountAdapter(DefaultAccountAdapter):
@@ -7,6 +12,22 @@ class CustomAccountAdapter(DefaultAccountAdapter):
         """
         Returns the frontend URL that will be used in the email.
         """
-        frontend_url = settings.FRONTEND_URL  # e.g., "http://localhost:3000"
+        frontend_url = settings.FRONTEND_URL
         key = emailconfirmation.key
         return f"{frontend_url}/confirm-email/{key}"
+
+
+class CustomSocialAccountAdapter(DefaultSocialAccountAdapter):
+    def save_user(self, request, sociallogin, form=None):
+        u = sociallogin.user
+        u.set_unusable_password()
+        account_adapter = get_account_adapter()
+        if form:
+            account_adapter.save_user(request, u, form)
+        else:
+            account_adapter.populate_username(request, u)
+        sociallogin.save(request, connect=True)
+
+        set_primary_email(user=u)
+
+        return u

--- a/backend/authentication/backends.py
+++ b/backend/authentication/backends.py
@@ -1,0 +1,31 @@
+from allauth.account.auth_backends import AuthenticationBackend
+from allauth.account.utils import filter_users_by_email
+
+
+class CustomAuthenticationBackend(AuthenticationBackend):
+    def _authenticate(self, request, **credentials):
+        username = credentials.get("username")
+        email = credentials.get("email")
+        password = str(credentials.get("password"))
+        if username:
+            user = self._authenticate_by_email(username, password)
+            if user:
+                return user
+
+            user = self._authenticate_by_username(username, password)
+            if user:
+                return user
+
+        if email:
+            user = self._authenticate_by_email(email, password)
+            if user:
+                return user
+
+        return None
+
+    def _authenticate_by_email(self, email: str, password: str):
+        users = filter_users_by_email(email, prefer_verified=True)
+        for user in users:
+            if self._check_password(user, password):
+                return user
+        return None

--- a/backend/authentication/serializers.py
+++ b/backend/authentication/serializers.py
@@ -1,5 +1,8 @@
 from dj_rest_auth.serializers import PasswordResetSerializer
-from dj_rest_auth.registration.serializers import RegisterSerializer
+from dj_rest_auth.registration.serializers import RegisterSerializer, get_adapter
+from allauth.account.models import EmailAddress
+from django.utils.translation import gettext_lazy as _
+from rest_framework import serializers
 from django.conf import settings
 
 
@@ -15,3 +18,11 @@ class CustomPasswordResetSerializer(PasswordResetSerializer):
 class PatchedRegisterSerializer(RegisterSerializer):
     def _has_phone_field(self):
         return False
+
+    def validate_email(self, email):
+        email = get_adapter().clean_email(email)
+        if email and EmailAddress.objects.is_verified(email):
+            raise serializers.ValidationError(
+                _("A user is already registered with this e-mail address."),
+            )
+        return email

--- a/backend/authentication/utils.py
+++ b/backend/authentication/utils.py
@@ -1,0 +1,16 @@
+from allauth.account.models import EmailAddress
+
+
+def set_primary_email(user):
+    try:
+        if user.email:
+            email = EmailAddress.objects.get(user=user, email=user.email)
+            email.set_as_primary(conditional=True)
+        else:
+            email = None
+
+    except EmailAddress.DoesNotExist:
+        email = EmailAddress.objects.create(user=user, email=user.email)
+        email.set_as_primary(conditional=True)
+
+    return email

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -125,7 +125,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 AUTHENTICATION_BACKENDS = [
     "django.contrib.auth.backends.ModelBackend",
-    "allauth.account.auth_backends.AuthenticationBackend",
+    "authentication.backends.CustomAuthenticationBackend",
 ]
 
 
@@ -193,11 +193,14 @@ SITE_ID = 1
 
 FRONTEND_URL = os.getenv("FRONTEND_URL", "http://localhost:5173")
 
-ACCOUNT_LOGIN_METHODS = {"email", "username"}
+ACCOUNT_LOGIN_METHODS = {"username"}
 ACCOUNT_SIGNUP_FIELDS = ["email*", "username*", "password1*", "password2*"]
 ACCOUNT_EMAIL_VERIFICATION = "mandatory"
 ACCOUNT_CONFIRM_EMAIL_ON_GET = True
 ACCOUNT_ADAPTER = "authentication.adapters.CustomAccountAdapter"
+ACCOUNT_UNIQUE_EMAIL = False
+
+SOCIALACCOUNT_ADAPTER = "authentication.adapters.CustomSocialAccountAdapter"
 
 # Email Config
 EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"


### PR DESCRIPTION
# Summary of Changes
## 1. Disable Automatic Email Verification for Social Accounts
- Updated `EmailAddress` model instance creation to mark new emails as **unverified** by default, rather than automatically marking them as verified.

- This change ensures that when creating an email-based user account, the system can accept an email address that may already be associated with an existing social account, without creating conflicts.

## 2. Custom Email-Based Authentication
- Introduced a custom authentication flow to allow registration via **email and password**, even if the provided email is already linked to a social account.

- This enables a seamless experience for users who wish to switch from social login to traditional email login, while preserving account integrity.