### PR TITLE
Implemented functionality to get Social Auth Redirect url from Social App Model

### DIFF
--- a/backend/authentication/views.py
+++ b/backend/authentication/views.py
@@ -1,5 +1,6 @@
 from allauth.socialaccount.providers.google.views import GoogleOAuth2Adapter
 from allauth.socialaccount.providers.github.views import GitHubOAuth2Adapter
+from allauth.socialaccount.models import SocialApp
 from dj_rest_auth.registration.views import SocialLoginView
 from .client import ScopedOAuth2Client
 
@@ -12,5 +13,5 @@ class GoogleLogin(SocialLoginView):
 
 class GitHubLogin(SocialLoginView):
     adapter_class = GitHubOAuth2Adapter
-    callback_url = "http://localhost:8000/accounts/github/login/callback/"
+    callback_url = SocialApp.objects.get(provider="github").settings["redirect_url"]
     client_class = ScopedOAuth2Client


### PR DESCRIPTION
This PR updates the **GitHubLoginView** class so that the `callback_url` attribute is now dynamically retrieved from the **SocialApp** model’s **settings["redirect_url"]** key instead of being hard-coded.

### Why this change is needed:

- Previously, changing the GitHub OAuth callback URL required a code change and redeploy.

- By fetching the callback URL from the **SocialApp** settings, we can update it directly in the database (via the admin panel or migrations) without modifying the application code.

- This approach improves flexibility, reduces downtime, and supports different callback URLs per environment (dev, staging, prod) without branching code.

### Changes made:

- Modified **GitHubLoginView** to load `callback_url `from `SocialApp.settings["redirect_url"]`.