### PR TITLE
Removed max width constraint at sm breakpoint

### DIFF
--- a/frontend/src/components/ui/Card.tsx
+++ b/frontend/src/components/ui/Card.tsx
@@ -9,9 +9,6 @@ const Card = styled(MuiCard)(({ theme }) => ({
   padding: theme.spacing(4),
   gap: theme.spacing(2),
   margin: "auto",
-  [theme.breakpoints.up("sm")]: {
-    maxWidth: "450px",
-  },
   boxShadow:
     "hsla(220, 30%, 5%, 0.05) 0px 5px 15px 0px, hsla(220, 25%, 10%, 0.05) 0px 15px 35px -5px",
   ...theme.applyStyles("dark", {


### PR DESCRIPTION
## Summary
This PR removes the `maxWidth` constraint from the reusable `Card` component to allow more flexibility in different UI contexts.

## Changes
- **Removed**: `maxWidth: "450px"` applied at the `sm` breakpoint in `Card` styled component.
- The `Card` component now fully expands based on its parent container width unless overridden where it’s used.

## Reasoning
- Some UI screens require the `Card` component to span wider than 450px.
- Previously, this constraint had to be overridden manually in each usage.
- Removing it in the base component avoids repetitive overrides and keeps the design system more flexible.

## Impact
- All uses of `Card` will now follow the container’s available width.
- Any layout previously relying on the `maxWidth` will need to handle that via parent container styles if needed.