### PR TITLE
fix(build): add Node types and correct type-only import to fix prod build

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,6 +24,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.30.1",
+        "@types/node": "^24.3.0",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "@vitejs/plugin-react": "^4.6.0",
@@ -1872,6 +1873,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
+      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.10.0"
+      }
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
@@ -4344,6 +4355,13 @@
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.9.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",
+    "@types/node": "^24.3.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",

--- a/frontend/src/theme/ColorModeIconDropdown.tsx
+++ b/frontend/src/theme/ColorModeIconDropdown.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import DarkModeIcon from '@mui/icons-material/DarkModeRounded';
 import LightModeIcon from '@mui/icons-material/LightModeRounded';
 import Box from '@mui/material/Box';
-import IconButton, { IconButtonOwnProps } from '@mui/material/IconButton';
+import IconButton, { type IconButtonOwnProps } from '@mui/material/IconButton';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import { useColorScheme } from '@mui/material/styles';

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -6,6 +6,9 @@
     "module": "ESNext",
     "skipLibCheck": true,
 
+    /* */
+    "types": ["node"],
+
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,


### PR DESCRIPTION
## Summary
This PR addresses production build failures caused by two separate but related issues.

### 1. Missing Node type declarations
- Added `@types/node` to `devDependencies` in `package.json`.
- Updated `tsconfig.node.json` to include `"types": ["node"]`.
- This resolves TypeScript errors like:
   - Cannot find module 'path' or its corresponding type declarations in `vite.config.ts`
### 2. Incorrect type import in `ColorModelIconDropdown`
- Updated the import for `IconButtonOwnProps` to use `import type`.
- Ensures the type is excluded from compiled JavaScript.
- Prevents build-time failures caused by treating a type as a value import.

## Changed Files
- `package.json`
- `package-lock.json`
- `tsconfig.node.json`
- `src/theme/ColorModelIconDropdown.tsx`

## Testing
- Ran `npm run build` locally — build completed successfully.
- Ran `npm run preview` and verified application runs without errors.

## Notes
Both fixes are included in the same PR as they are required together to resolve the production build failure.