### PR TITLE
fix: clarified env var names

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -30,12 +30,19 @@ SECRET_KEY = os.getenv(
 )
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True if os.getenv("DEBUG", "True") == "True" else False
+DEBUG = os.getenv("DEBUG", "False").strip().lower() == "true"
 
 ALLOWED_HOSTS = [
-    os.getenv("BACKEND_DOMAIN", "localhost"),
+    os.getenv("BACKEND_HOST", "localhost"),
 ]
 
+# CORS
+CORS_ALLOWED_ORIGINS = [
+    os.getenv("FRONTEND_URL", "http://localhost:5173"),
+]
+
+CORS_ALLOW_ALL_ORIGINS = DEBUG
+CORS_ALLOW_CREDENTIALS = True
 
 # Application definition
 
@@ -153,14 +160,6 @@ STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
-
-# CORS
-CORS_ALLOWED_ORIGINS = [
-    os.getenv("FRONTEND_DOMAIN", "http://localhost:5173"),
-]
-
-CORS_ALLOW_ALL_ORIGINS = os.getenv("DEBUG", "True") is True
-CORS_ALLOW_CREDENTIALS = True
 
 # REST Framework
 REST_FRAMEWORK = {


### PR DESCRIPTION
## Summary

This update makes it **easier to understand and configure** the environment variables for the backend.  
No deep programming knowledge is required to follow along — just update the `.env` file with the right values.

---

## 1️⃣ DEBUG (turning developer mode on/off)

**Before:**  
We used a setting that only worked if the value was exactly `True` (case-sensitive), which could be confusing.

**Now:**  
You can write `true`, `True`, or `  true  ` (with spaces) and it will work.

**In your `.env` file:**
```env
DEBUG=true   # developer mode on
```
or
```env
DEBUG=false # developer mode off
```

## 2️⃣ ALLOWED_HOSTS (where the backend accepts requests from)

**Before:**
We used `BACKEND_DOMAIN` and it wasn’t clear what to put.

**Now:**
We use `BACKEND_HOST`, and it should only be the hostname (no `http://` or `https://`).

**Example:**
```env
BACKEND_HOST=localhost
```
or
```env
BACKEND_HOST=api.mydomain.com
```

## 3️⃣ FRONTEND_URL (where the website/app is hosted)

**Before:**
We used `FRONTEND_DOMAIN` and it wasn’t clear whether to add `http://` or not.

**Now:
We use `FRONTEND_URL`, and you must include the `http://` or `https://`.

**Example:**
```env
FRONTEND_URL=https://mydomain.com
```
or
```env
FRONTEND_URL=http://localhost:5173
```

## ✅ Summary of changes:

- `DEBUG` now works in a case-insensitive way.

- `BACKEND_HOST` replaces `BACKEND_DOMAIN` (host only, no protocol).

- `FRONTEND_URL` replaces `FRONTEND_DOMAIN` (full URL with protocol).

- Settings are more predictable and match what Django expects.