### PR TITLE
Removed Theme Toggle Button from Auth Pages

### DIFF
--- a/frontend/src/pages/auth/SignIn.tsx
+++ b/frontend/src/pages/auth/SignIn.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import ColorModeSelect from "../../theme/ColorModeSelect";
 import SignInContainer from "../../components/auth/AuthContainer";
 import Card from "../../components/ui/Card";
 import SignInForm from "@/components/auth/SignInForm";
@@ -37,7 +36,6 @@ const SignInPage: React.FC = () => {
   };
   return (
     <SignInContainer direction="column" justifyContent="space-between">
-      <ColorModeSelect sx={{ position: "fixed", top: "1rem", right: "1rem" }} />
       <Card variant="outlined">
         <Typography
           component="h1"

--- a/frontend/src/pages/auth/SignUp.tsx
+++ b/frontend/src/pages/auth/SignUp.tsx
@@ -5,7 +5,6 @@ import { API_ENDPOINTS, INTERNAL_SERVER_ERROR_MESSAGE } from "@/constants/api";
 import { api } from "@/lib/api";
 import type { SignUpPayload } from "@/schema/auth";
 import { useToastStore } from "@/store/toastStore";
-import ColorModeSelect from "@/theme/ColorModeSelect";
 import type { SignUpErrorResponse, SignUpSuccessResponse } from "@/types/auth";
 import { Typography } from "@mui/material";
 import { useState } from "react";
@@ -31,7 +30,6 @@ export default function SignUp() {
   };
   return (
     <SignInContainer direction="column" justifyContent="space-between">
-      <ColorModeSelect sx={{ position: "fixed", top: "1rem", right: "1rem" }} />
       <Card variant="outlined" sx={{ overflow: "clip" }}>
         <Typography
           component="h1"


### PR DESCRIPTION
## Summary  
This PR removes the `ColorModeButton` from the **Sign In** and **Sign Up** pages since it is already included in the global header.

## Context / Reason  
- The `ColorModeButton` component was previously used in the auth pages.  
- A recent change updated the component to no longer accept the `sx` property.  
- Since the auth pages were still passing `sx`, this caused **build failures in production**.  
- Additionally, the component has now been **permanently moved to the header** as part of the UI/UX improvements, so it is redundant in the auth pages.

## Changes Made  
- Removed the `ColorModeButton` from the Sign In and Sign Up pages.  
- Verified that the component still appears in the header as expected.

## Testing  
- ✅ Ran `npm run build` — build completed successfully.  
- ✅ Ran `npm run preview` — application works as intended in the browser, and the button is visible in the header.  

## Notes  
This change is **safe** as the component is globally included in the header and no functionality is lost.