### PR TITLE
Modified the Callback URL by providing a default value if the model doesn't exist

### DIFF
--- a/backend/authentication/views.py
+++ b/backend/authentication/views.py
@@ -1,17 +1,35 @@
+import os
+from allauth.socialaccount.models import SocialApp
 from allauth.socialaccount.providers.google.views import GoogleOAuth2Adapter
 from allauth.socialaccount.providers.github.views import GitHubOAuth2Adapter
-from allauth.socialaccount.models import SocialApp
 from dj_rest_auth.registration.views import SocialLoginView
+from dotenv import load_dotenv
 from .client import ScopedOAuth2Client
+
+load_dotenv()
+
+
+def get_redirect_url(provider: str, default_url: str) -> str:
+    """Fetch redirect_url from SocialApp.settings, or fall back to default."""
+    try:
+        app = SocialApp.objects.get(provider=provider)
+        return app.settings.get("redirect_url", default_url)
+    except (SocialApp.DoesNotExist, Exception):
+        return default_url
 
 
 class GoogleLogin(SocialLoginView):
     adapter_class = GoogleOAuth2Adapter
-    callback_url = "http://localhost:8000/accounts/google/login/callback/"
     client_class = ScopedOAuth2Client
+    callback_url = get_redirect_url(
+        "google",
+        f"{os.getenv("BACKEND_DOMAIN", "http://localhost:8000")}/accounts/google/login/callback/",
+    )
 
 
 class GitHubLogin(SocialLoginView):
     adapter_class = GitHubOAuth2Adapter
-    callback_url = SocialApp.objects.get(provider="github").settings["redirect_url"]
     client_class = ScopedOAuth2Client
+    callback_url = get_redirect_url(
+        "github", f"{os.getenv("FRONTEND_URL", "http://localhost:5173")}/auth/sign-in/github"
+    )


### PR DESCRIPTION
## Fixes

Modified the `callback_url` attribute of the **Google and GitHub login views** by providing a default value in case the Social App model doesn't exist.

## Reason

Since we provided the `callback_url` attribute a value from the `SocialApp` model, **the build failed**. This was because we were trying to access a model **before the migrations are made**, i.e., the model is created.

## Testing

Tried deleting the test database and then migrating the models to check if the build failed. The test passed successfully and the migrations completed **without errors**.