### PR TITLE
Implemented Token Refresh Mechanism in case of Expired Access Token

### DIFF
--- a/frontend/src/constants/api.ts
+++ b/frontend/src/constants/api.ts
@@ -13,6 +13,8 @@ export const API_ENDPOINTS = {
     RESEND_VERIFICATION_EMAIL: "/api/auth/registration/resend-email/",
     VERIFY_EMAIL: "/api/auth/registration/verify-email/",
 
+    REFRESH_ACCESS_TOKEN: "/api/auth/token/refresh/",
+
     SIGN_IN: "/api/auth/login/",
     GOOGLE_SIGN_IN: "/api/auth/google/",
     GITHUB_SIGN_IN: "/api/auth/github/",


### PR DESCRIPTION
## Summary

This PR refactors the Axios instance and refresh token logic:

- Handles 401 responses properly while keeping validateStatus <= 500
- Implements refreshToken function for cookie-based JWT (no frontend token handling)
- Cleans up unnecessary manual 401 rejection
- Preserves _retry logic to prevent infinite loops
- Keeps CustomAxiosResponse type for discriminated union success/error

Now, any API call returning 401 will automatically call the refresh endpoint and retry the original request.

## Testing Notes

- Simulated an expired access token by removing the access token cookie in the browser.
- Navigated to the protected Notes page `/notes`.
- The frontend called `Fetch User Profile API` to check authentication.
- Axios interceptor detected the **401 response** and automatically called the refresh token endpoint.
- Refresh succeeded, updating the HttpOnly cookies.
- Original `Fetch User Profile API` request was retried automatically and returned 200.

The Notes page **loaded successfully**, confirming the refresh flow works as expected.